### PR TITLE
Initialisation script for CAA

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,4 +1,3 @@
 asyncpg~=0.22.0
 prompt_toolkit~=2.0.9
 git+https://github.com/webpy/webpy.git#egg=web.py
-qrcode[pil]~=6.1

--- a/demo/run_demo
+++ b/demo/run_demo
@@ -144,7 +144,7 @@ else
 fi
 
 echo "Preparing agent image..."
-docker build -q -t fly2plan-ssi-demo -f ../docker/Dockerfile.demo .. || exit 1
+docker build -q -t ssi-demo -f ../docker/Dockerfile.demo .. || exit 1
 
 if [ ! -z "$DOCKERHOST" ]; then
   # provided via APPLICATION_URL environment variable
@@ -247,4 +247,4 @@ $DOCKER run --name $AGENT --rm -it ${DOCKER_OPTS} \
   -p 0.0.0.0:$AGENT_PORT_RANGE:$AGENT_PORT_RANGE \
   ${DOCKER_VOL} \
   $DOCKER_ENV \
-  fly2plan-ssi-demo $AGENT_MODULE --port $AGENT_PORT $ARGS
+  ssi-demo $AGENT_MODULE --port $AGENT_PORT $ARGS

--- a/demo/run_demo
+++ b/demo/run_demo
@@ -87,7 +87,7 @@ do
     continue
   ;;
   --bg)
-    if [ "${AGENT}" = "alice" ] || [ "${AGENT}" = "airops" ] || [ "${AGENT}" = "consortiq" ]; then
+    if [ "${AGENT}" = "alice" ] || [ "${AGENT}" = "airops" ] || [ "${AGENT}" = "consortiq" ] || [ "${AGENT}" = "caa" ]; then
       DOCKER_OPTS="-d"
       echo -e "\nRunning in ${AGENT} in the background. Note that you cannot use the command line console in this mode."
       echo To see the logs use: \"docker logs ${AGENT}\".
@@ -134,8 +134,12 @@ elif [ "$AGENT" = "airops" ]; then
   AGENT_MODULE="airops"
   AGENT_PORT=8040
   AGENT_PORT_RANGE=8040-8047
+elif [ "$AGENT" = "caa" ]; then
+  AGENT_MODULE="caa"
+  AGENT_PORT=8050
+  AGENT_PORT_RANGE=8050-8057
 else
-  echo "Please specify which agent you want to run. Choose from 'consortiq', 'dpilot', or 'airops'."
+  echo "Please specify which agent you want to run. Choose from 'consortiq', 'alice', 'airops' or 'caa'."
   exit 1
 fi
 

--- a/demo/runners/agent_container.py
+++ b/demo/runners/agent_container.py
@@ -1108,17 +1108,6 @@ async def test_main(
         await airops_container.initialize()
         await caa_container.initialize()
 
-        # consortiq create invitation
-        # invite = await consortiq_container.generate_invitation()
-
-        # alice accept invitation
-        # invite_details = invite["invitation"]
-        # connection = await alice_container.input_invitation(invite_details)
-
-        # wait for consortiq connection to activate
-        # await consortiq_container.detect_connection()
-        # await alice_container.detect_connection()
-
         log_msg("Sleeping ...")
         await asyncio.sleep(3.0)
 
@@ -1137,8 +1126,11 @@ async def test_main(
                 log_msg("Shutting down consortiq agent ...")
                 await consortiq_container.terminate()
             if airops_container:
-                log_msg("Shutting down consortiq agent ...")
-                await consortiq_container.terminate()
+                log_msg("Shutting down airops agent ...")
+                await airops_container.terminate()
+            if caa_container:
+                log_msg("Shutting down caa agent ...")
+                await caa_container.terminate()
         except Exception as e:
             LOGGER.exception("Error terminating agent:", e)
             terminated = False

--- a/demo/runners/caa.py
+++ b/demo/runners/caa.py
@@ -14,6 +14,18 @@ from runners.agent_container import (  # noqa:E402
     create_agent_with_args,
     AriesAgent,
 )
+# from runners.support.agent import (  # noqa:E402
+#     CRED_FORMAT_INDY,
+#     CRED_FORMAT_JSON_LD,
+#     SIG_TYPE_BLS,
+# )
+# from runners.support.utils import (  # noqa:E402
+#     log_msg,
+#     log_status,
+#     prompt,
+#     prompt_loop,
+# )
+
 
 CRED_PREVIEW_TYPE = "https://didcomm.org/issue-credential/2.0/credential-preview"
 SELF_ATTESTED = os.getenv("SELF_ATTESTED")
@@ -43,8 +55,6 @@ class CaaAgent(AriesAgent):
         self.connection_id = None
         self._connection_ready = None
         self.cred_state = {}
-        # TODO define a dict to hold credential attributes
-        # based on cred_def_id
         self.cred_attrs = {}
 
     async def detect_connection(self):
@@ -57,7 +67,18 @@ class CaaAgent(AriesAgent):
 
 
 async def main(args):
-    print(200)
+    consortiq_agent = ""
+
+    try:
+        print(200)
+
+    finally:
+        terminated = False
+
+    await asyncio.sleep(0.1)
+
+    if not terminated:
+        os._exit(1)
 
 if __name__ == "__main__":
     parser = arg_parser(ident="caa", port=8050)

--- a/demo/runners/caa.py
+++ b/demo/runners/caa.py
@@ -1,9 +1,7 @@
 import asyncio
-# import json
 import logging
 import os
 import sys
-# import time
 
 # from aiohttp import ClientError
 
@@ -55,7 +53,6 @@ class CaaAgent(AriesAgent):
         self.connection_id = None
         self._connection_ready = None
         self.cred_state = {}
-        # self.cred_attrs = {}
     async def detect_connection(self):
         await self._connection_ready
         self._connection_ready = None
@@ -71,7 +68,7 @@ async def main(args):
 
     try:
         log_status(
-            "#1 Provision an agent and wallet, get back configuration details"
+            "Provision an agent and wallet, get back configuration details"
             + (
                 f" (Wallet type: {caa_agent.wallet_type})"
                 if caa_agent.wallet_type
@@ -99,11 +96,9 @@ async def main(args):
             raise Exception("Invalid credential type:" + caa_agent.cred_type)
 
         options = (
-            # "    (1) Issue Credential\n"
-            # "    (2) Send Proof Request\n"
             "    (1) Send Message\n"
             "    (X) Exit?\n"
-            "[1/2/3/X]"
+            "[1/X]"
         )
         async for option in prompt_loop(options):
             if option is not None:
@@ -114,7 +109,6 @@ async def main(args):
 
             elif option == "1":
                 msg = await prompt("Enter message: ")
-                import json
                 if len(connections["results"]) == 0:
                     caa_agent.agent.log(
                         "No connections available. There are {} connection(s).".format(len(connections))
@@ -140,7 +134,7 @@ async def main(args):
 if __name__ == "__main__":
     parser = arg_parser(ident="caa", port=8050)
     args = parser.parse_args()
-    # Namespace(aip=20, arg_file=None, cred_type='indy', did_exchange=False, mediation=False, multitenant=False, no_auto=False, port=8050, revocation=False, tails_server_base_url=None, timing=False, wallet_type=None)
+
     ENABLE_PYDEVD_PYCHARM = os.getenv("ENABLE_PYDEVD_PYCHARM", "").lower()
     ENABLE_PYDEVD_PYCHARM = ENABLE_PYDEVD_PYCHARM and ENABLE_PYDEVD_PYCHARM not in (
         "false",
@@ -168,7 +162,7 @@ if __name__ == "__main__":
             )
         except ImportError:
             print("pydevd_pycharm library was not found")
-    print(200) #
+
     try:
         asyncio.get_event_loop().run_until_complete(main(args))
     except KeyboardInterrupt:

--- a/demo/runners/caa.py
+++ b/demo/runners/caa.py
@@ -1,0 +1,97 @@
+import asyncio
+# import json
+import logging
+import os
+import sys
+# import time
+
+# from aiohttp import ClientError
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from runners.agent_container import (  # noqa:E402
+    arg_parser,
+    create_agent_with_args,
+    AriesAgent,
+)
+
+CRED_PREVIEW_TYPE = "https://didcomm.org/issue-credential/2.0/credential-preview"
+SELF_ATTESTED = os.getenv("SELF_ATTESTED")
+TAILS_FILE_COUNT = int(os.getenv("TAILS_FILE_COUNT", 100))
+
+logging.basicConfig(level=logging.WARNING)
+LOGGER = logging.getLogger(__name__)
+
+
+class CaaAgent(AriesAgent):
+    def __init__(
+        self,
+        ident: str,
+        http_port: int,
+        admin_port: int,
+        no_auto: bool = False,
+        **kwargs,
+    ):
+        super().__init__(
+            ident,
+            http_port,
+            admin_port,
+            prefix="Caa",
+            no_auto=no_auto,
+            **kwargs,
+        )
+        self.connection_id = None
+        self._connection_ready = None
+        self.cred_state = {}
+        # TODO define a dict to hold credential attributes
+        # based on cred_def_id
+        self.cred_attrs = {}
+
+    async def detect_connection(self):
+        await self._connection_ready
+        self._connection_ready = None
+
+    @property
+    def connection_ready(self):
+        return self._connection_ready.done() and self._connection_ready.result()
+
+
+async def main(args):
+    print(200)
+
+if __name__ == "__main__":
+    parser = arg_parser(ident="caa", port=8050)
+    args = parser.parse_args()
+    # Namespace(aip=20, arg_file=None, cred_type='indy', did_exchange=False, mediation=False, multitenant=False, no_auto=False, port=8050, revocation=False, tails_server_base_url=None, timing=False, wallet_type=None)
+    ENABLE_PYDEVD_PYCHARM = os.getenv("ENABLE_PYDEVD_PYCHARM", "").lower()
+    ENABLE_PYDEVD_PYCHARM = ENABLE_PYDEVD_PYCHARM and ENABLE_PYDEVD_PYCHARM not in (
+        "false",
+        "0",
+    )
+    PYDEVD_PYCHARM_HOST = os.getenv("PYDEVD_PYCHARM_HOST", "localhost")
+    PYDEVD_PYCHARM_CONTROLLER_PORT = int(
+        os.getenv("PYDEVD_PYCHARM_CONTROLLER_PORT", 5001)
+    )
+
+    if ENABLE_PYDEVD_PYCHARM:
+        try:
+            import pydevd_pycharm
+
+            print(
+                "CAA remote debugging to "
+                f"{PYDEVD_PYCHARM_HOST}:{PYDEVD_PYCHARM_CONTROLLER_PORT}"
+            )
+            pydevd_pycharm.settrace(
+                host=PYDEVD_PYCHARM_HOST,
+                port=PYDEVD_PYCHARM_CONTROLLER_PORT,
+                stdoutToServer=True,
+                stderrToServer=True,
+                suspend=False,
+            )
+        except ImportError:
+            print("pydevd_pycharm library was not found")
+
+    try:
+        asyncio.get_event_loop().run_until_complete(main(args))
+    except KeyboardInterrupt:
+        os._exit(1)


### PR DESCRIPTION
# CAA - Initialisation Script

> Add an additional script to the demo startup process to anchor (register) a public DID for the CAA.
>
> AC: 1). Anchor a new public DID for CAA; 2). Create alias for CAA ( Should be visible on VON explorer page ); 3). Create endpoint attribute data that is inserted on the chain.

- [x] Changed the run_demo wrapper script to include code for CAA;
- [x] Added a new python script ( caa.py );
- [x] Implemented python script same way it was implemented for Consortiq and Airops;
- [x] Cleaned up the agent_container.py dependency file;
- [x] Tested.

In order to run this, first start the VON network:

```sh
./manage start --wait
```

After that go back into the demo/ folder and run:

```
./run_demo caa
```

If you see errors, don't forget to add the 3 export lines:

```sh
export MYIP=`ifconfig | grep broadcast | cut -d ' ' -f2`
export DOCKER_NET=von_von
export DOCKERHOST=${MYIP}
```

This is connected to ticket 51.
