### PR TITLE
🐛 BUG: Wrong version of Web Py inside demo/requirements.txt

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,4 +1,4 @@
 asyncpg~=0.22.0
 prompt_toolkit~=2.0.9
-git+https://github.com/webpy/webpy.git#egg=web.py
+git+https://github.com/webpy/webpy.git@0.40#egg=web.py
 qrcode[pil]~=6.1


### PR DESCRIPTION
---
name: 🐛 BUG: Wrong version of Web Py inside demo/requirements.txt
about: The build process is trying to use a new version of Web Py which is not compatible with the rest of the project.
---

<!--

Have you read fly2plan-aries-cloudagent's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/digicatapult/fly2plan-aries-cloudagent/.github/blob/main/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Checked the FAQs for common solutions: <https://github.com/digicatapult/fly2plan-aries-cloudagent/blob/main/CONTRIBUTING.md/#FAQs>
- [x] Checked that your issue isn't already filed: <https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Afly2plan-aries-cloudagent>

### Description

<!-- Description of the issue -->

### Steps to Reproduce

1. Clone the main repository, as in `fly2plan-poc` including all the git submodules.
2. Remove all docker images ( e.g.: _fly2plan-ssi-demo_ ) and containers related to this project.
3. Run the `./start.sh` script.

**Expected behaviour:**

The entire stack should start without issues.

**Actual behaviour:**

The docker build process fails in the middle of the build, therefore process of spinning-up containers doesn't work either.

**Reproduces how often:**

<!-- What percentage of the time does it reproduce? -->

### Versions

N/A

### Additional Information

The current setup stops with the following error:

```
$ docker build -t fly2plan-ssi-demo -f docker/Dockerfile.demo .
[+] Building 17.6s (17/18)
 => [internal] load build definition from Dockerfile.demo                                                                                                                                                  0.0s
 => => transferring dockerfile: 42B                                                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/bcgovimages/von-image:py36-1.15-1                                                                                                                               0.5s
 => [ 1/14] FROM docker.io/bcgovimages/von-image:py36-1.15-1@sha256:7ba9452bbda1b5d03f117451ba6504f30cfe5598e74ff78f3e6e4ce29a206c65                                                                       0.0s
 => [internal] load build context                                                                                                                                                                          0.1s
 => => transferring context: 105.19kB                                                                                                                                                                      0.1s
 => CACHED [ 2/14] RUN mkdir bin && curl -L -o bin/jq  https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 &&  chmod ug+x bin/jq                                                            0.0s
 => CACHED [ 3/14] ADD requirements*.txt ./                                                                                                                                                                0.0s
 => CACHED [ 4/14] RUN pip3 install --no-cache-dir  -r requirements.txt  -r requirements.askar.txt  -r requirements.bbs.txt  -r requirements.dev.txt                                                       0.0s
 => CACHED [ 5/14] ADD aries_cloudagent ./aries_cloudagent                                                                                                                                                 0.0s
 => CACHED [ 6/14] ADD bin ./bin                                                                                                                                                                           0.0s
 => CACHED [ 7/14] ADD README.md ./                                                                                                                                                                        0.0s
 => CACHED [ 8/14] ADD scripts ./scripts                                                                                                                                                                   0.0s
 => CACHED [ 9/14] ADD setup.py ./                                                                                                                                                                         0.0s
 => CACHED [10/14] RUN pip3 install --no-cache-dir -e .                                                                                                                                                    0.0s
 => CACHED [11/14] RUN mkdir demo logs && chown -R indy:indy demo logs && chmod -R ug+rw demo logs                                                                                                         0.0s
 => CACHED [12/14] ADD demo/requirements.txt ./demo/requirements.txt                                                                                                                                       0.0s
 => ERROR [13/14] RUN pip3 install --no-cache-dir -r demo/requirements.txt                                                                                                                                16.9s
------
 > [13/14] RUN pip3 install --no-cache-dir -r demo/requirements.txt:
#17 3.685 Collecting web.py
#17 3.687   Cloning https://github.com/webpy/webpy.git to /tmp/pip-install-yfizynn8/web-py_012e1833c22f4bb89792f5324ad276c2
#17 3.688   Running command git clone -q https://github.com/webpy/webpy.git /tmp/pip-install-yfizynn8/web-py_012e1833c22f4bb89792f5324ad276c2
#17 5.570   Installing build dependencies: started
#17 13.19   Installing build dependencies: finished with status 'error'
#17 13.19   ERROR: Command errored out with exit status 1:
#17 13.19    command: /home/indy/.pyenv/versions/3.6.13/bin/python3.6 /home/indy/.pyenv/versions/3.6.13/lib/python3.6/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-fbyii5wd/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=61.2'
#17 13.19        cwd: None
#17 13.19   Complete output (4 lines):
#17 13.19   ERROR: Could not find a version that satisfies the requirement setuptools>=61.2
#17 13.19   ERROR: No matching distribution found for setuptools>=61.2
#17 13.19   WARNING: You are using pip version 21.0.1; however, version 21.3.1 is available.
#17 13.19   You should consider upgrading via the '/home/indy/.pyenv/versions/3.6.13/bin/python3.6 -m pip install --upgrade pip' command.
#17 13.19   ----------------------------------------
#17 13.19 WARNING: Discarding git+https://github.com/webpy/webpy.git#egg=web.py. Command errored out with exit status 1: /home/indy/.pyenv/versions/3.6.13/bin/python3.6 /home/indy/.pyenv/versions/3.6.13/lib/python3.6/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-fbyii5wd/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=61.2' Check the logs for full command output.
#17 14.52 Collecting asyncpg~=0.22.0
#17 14.63   Downloading asyncpg-0.22.0-cp36-cp36m-manylinux1_x86_64.whl (2.8 MB)
#17 15.02 Requirement already satisfied: prompt_toolkit~=2.0.9 in ./.pyenv/versions/3.6.13/lib/python3.6/site-packages (from -r demo/requirements.txt (line 2)) (2.0.10)
#17 15.03 ERROR: Could not find a version that satisfies the requirement web-py (unavailable)
#17 15.03 ERROR: No matching distribution found for web-py (unavailable)
#17 16.71 WARNING: You are using pip version 21.0.1; however, version 21.3.1 is available.
#17 16.71 You should consider upgrading via the '/home/indy/.pyenv/versions/3.6.13/bin/python3.6 -m pip install --upgrade pip' command.
------
executor failed running [/bin/sh -c pip3 install --no-cache-dir -r demo/requirements.txt]: exit code: 1
DIGI-ABaloiu:fly2plan-aries-cloudagent andy$
```

A quick solution is being proposed here which is to just pin down the _WebPy_ version used inside `./demo/requirements.txt` to `0.40`. Version 0.40 was created awhile ago therefore it works without any issues. 

If you see errors, don't forget to add the 3 export lines:

```sh
export MYIP=`ifconfig | grep broadcast | cut -d ' ' -f2`
export DOCKER_NET=von_von
export DOCKERHOST=${MYIP}
```

<!-- Any additional information, configuration or data that might be necessary to reproduce the issue. -->